### PR TITLE
Fix 4564 4559 4560

### DIFF
--- a/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
@@ -79,55 +79,55 @@ Docker logs backward compatibility
     Should Contain  ${output}  container ${id1} does not support '--timestamps'
 
 Docker logs with tail
-    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} create busybox sh -c 'seq 1 5000'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox sh -c 'seq 1 5000'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} start ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
     Should Be Equal As Integers  ${rc}  0
     Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  2500  5000
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --tail=all ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=all ${id}
     ${linecount}=  Get Line Count  ${output}
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Integers  ${linecount}  5000
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --tail=200 ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=200 ${id}
     ${linecount}=  Get Line Count  ${output}
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Integers  ${linecount}  200
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --tail=0 ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=0 ${id}
     Should Be Equal As Integers  ${rc}  0
     ${linecount}=  Get Line Count  ${output}
     Should Be Equal As Integers  ${linecount}  0
 
 Docker logs with follow
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} create busybox sh -c 'for i in $(seq 1 5) ; do sleep 1 && echo line $i; done'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox sh -c 'for i in $(seq 1 5) ; do sleep 1 && echo line $i; done'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} start ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --follow ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
     Should Be Equal As Integers  ${rc}  0
     ${linecount}=  Get Line Count  ${output}
     Should Be Equal As Integers  ${linecount}  5
     ${lastline}=  Get Line  ${output}  4
     Should Contain  ${lastline}  line 5
     # Container is stopped at this point, verify that --follow does not block.
-    ${rc}  ${output2}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --follow ${id}
+    ${rc}  ${output2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
     Should Be Equal  ${output}  ${output2}
 
 Docker logs with follow and tail
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} create busybox sh -c 'trap "seq 11 20; exit" HUP; seq 1 10; while true; do sleep 1; done'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox sh -c 'trap "seq 11 20; exit" HUP; seq 1 10; while true; do sleep 1; done'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} start ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
     Should Be Equal As Integers  ${rc}  0
     # Wait for the first 10 lines to be logged
     Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  5  10
     # kill -HUP will create another 5 lines of log output
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} kill -s HUP ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} kill -s HUP ${id}
     Should Be Equal As Integers  ${rc}  0
     # --tail=5 to skip the first 5 lines and --follow to wait for the rest
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --tail 5 --follow ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail 5 --follow ${id}
     Should Be Equal As Integers  ${rc}  0
     ${linecount}=  Get Line Count  ${output}
     Should Be True  ${linecount} >= 5
@@ -140,24 +140,24 @@ Docker logs follow shutdown
     # Note that the interaction layer currently uses an extra super tiny buffer size of 64 bytes.
     ${rc}  ${buffer}=  Run And Return Rc And Output  bash -c "printf '=%.0s' {1..65}"
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} create busybox sh -c 'echo ${buffer}; sleep .5; echo ${buffer}'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox sh -c 'echo ${buffer}; sleep .5; echo ${buffer}'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} start ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --follow ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal  ${output}  ${buffer}\n${buffer}
 
 Docker binary logs
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull ubuntu
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ubuntu
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} run ubuntu /bin/cat /bin/hostname >/tmp/hostname
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ubuntu /bin/cat /bin/hostname >/tmp/hostname
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} ps -a |grep ubuntu |awk '{print $1}'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a |grep ubuntu |awk '{print $1}'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs ${id} >/tmp/hostname-log
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${id} >/tmp/hostname-log
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${h1}=  Run And Return Rc And Output  sha256sum /tmp/hostname |awk '{print $1}'
     Should Be Equal As Integers  ${rc}  0
@@ -168,11 +168,11 @@ Docker binary logs
     Should Be Equal As Integers  ${rc}  0
 
 Docker text logs
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} run ubuntu /bin/ls >/tmp/ls
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ubuntu /bin/ls >/tmp/ls
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} ps -a |grep /bin/ls |awk '{print $1}'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a |grep /bin/ls |awk '{print $1}'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs ${id} >/tmp/ls-log
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${id} >/tmp/ls-log
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${h1}=  Run And Return Rc And Output  sha256sum /tmp/ls |awk '{print $1}'
     Should Be Equal As Integers  ${rc}  0
@@ -186,29 +186,29 @@ Docker logs with timestamps and since certain time
     ${status}=  Get State Of Github Issue  2539
     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-8-Docker-Logs.robot needs to be updated now that Issue #2539 has been resolved
     Log  Issue \#2539 is blocking implementation  WARN
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${containerID}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} create busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;'
+    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} start ${containerID}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
     Should Be Equal As Integers  ${rc}  0
     Run  Sleep 6, wait for container to finish
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --since=1s ${containerID}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --since=1s ${containerID}
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  container ${containerID} does not support '--since'
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --timestamps ${containerID}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${containerID}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  container ${containerID} does not support '--timestamps'
 
 Docker logs with no flags
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} run -d busybox sh -c "seq 1 128 | xargs -n1 echo"
+    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d busybox sh -c "seq 1 128 | xargs -n1 echo"
     Should Be Equal As Integers  ${rc}  0
     Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  42  128
 
 Docker logs non-existent container
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs fakeContainer
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs fakeContainer
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Error: No such container: fakeContainer
 

--- a/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
@@ -57,77 +57,77 @@ Check Upgraded Version
 *** Test Cases ***
 # This test happens first because the rest of the tests need the latest VCH after the upgrade step
 Docker logs backward compatibility
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id1}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d busybox sh -c "echo These pretzels are making me thirsty"
+    ${rc}  ${id1}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} run -d busybox sh -c "echo These pretzels are making me thirsty"
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${id1}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs ${id1}
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  These pretzels are making me thirsty
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${id1}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --timestamps ${id1}
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  vSphere Integrated Containers does not yet support '--timestamps'
     Upgrade
     Check Upgraded Version
-    ${rc}  ${id2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d busybox sh -c "echo Whats the deeeal with Ovaltine?"
+    ${rc}  ${id2}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} run -d busybox sh -c "echo Whats the deeeal with Ovaltine?"
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${id2}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --timestamps ${id2}
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Whats the deeeal with Ovaltine?
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${id1}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --timestamps ${id1}
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  container ${id1} does not support '--timestamps'
 
 Docker logs with tail
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox sh -c 'seq 1 5000'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} create busybox sh -c 'seq 1 5000'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} start ${id}
     Should Be Equal As Integers  ${rc}  0
     Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  2500  5000
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=all ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --tail=all ${id}
     ${linecount}=  Get Line Count  ${output}
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Integers  ${linecount}  5000
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=200 ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --tail=200 ${id}
     ${linecount}=  Get Line Count  ${output}
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal As Integers  ${linecount}  200
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail=0 ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --tail=0 ${id}
     Should Be Equal As Integers  ${rc}  0
     ${linecount}=  Get Line Count  ${output}
     Should Be Equal As Integers  ${linecount}  0
 
 Docker logs with follow
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox sh -c 'for i in $(seq 1 5) ; do sleep 1 && echo line $i; done'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} create busybox sh -c 'for i in $(seq 1 5) ; do sleep 1 && echo line $i; done'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} start ${id}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --follow ${id}
     Should Be Equal As Integers  ${rc}  0
     ${linecount}=  Get Line Count  ${output}
     Should Be Equal As Integers  ${linecount}  5
     ${lastline}=  Get Line  ${output}  4
     Should Contain  ${lastline}  line 5
     # Container is stopped at this point, verify that --follow does not block.
-    ${rc}  ${output2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
+    ${rc}  ${output2}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --follow ${id}
     Should Be Equal  ${output}  ${output2}
 
 Docker logs with follow and tail
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox sh -c 'trap "seq 11 20; exit" HUP; seq 1 10; while true; do sleep 1; done'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} create busybox sh -c 'trap "seq 11 20; exit" HUP; seq 1 10; while true; do sleep 1; done'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} start ${id}
     Should Be Equal As Integers  ${rc}  0
     # Wait for the first 10 lines to be logged
     Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  5  10
     # kill -HUP will create another 5 lines of log output
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} kill -s HUP ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} kill -s HUP ${id}
     Should Be Equal As Integers  ${rc}  0
     # --tail=5 to skip the first 5 lines and --follow to wait for the rest
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --tail 5 --follow ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --tail 5 --follow ${id}
     Should Be Equal As Integers  ${rc}  0
     ${linecount}=  Get Line Count  ${output}
     Should Be True  ${linecount} >= 5
@@ -140,24 +140,24 @@ Docker logs follow shutdown
     # Note that the interaction layer currently uses an extra super tiny buffer size of 64 bytes.
     ${rc}  ${buffer}=  Run And Return Rc And Output  bash -c "printf '=%.0s' {1..65}"
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox sh -c 'echo ${buffer}; sleep .5; echo ${buffer}'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} create busybox sh -c 'echo ${buffer}; sleep .5; echo ${buffer}'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} start ${id}
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --follow ${id}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --follow ${id}
     Should Be Equal As Integers  ${rc}  0
     Should Be Equal  ${output}  ${buffer}\n${buffer}
 
 Docker binary logs
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull ubuntu
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull ubuntu
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ubuntu /bin/cat /bin/hostname >/tmp/hostname
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} run ubuntu /bin/cat /bin/hostname >/tmp/hostname
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a |grep ubuntu |awk '{print $1}'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} ps -a |grep ubuntu |awk '{print $1}'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${id} >/tmp/hostname-log
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs ${id} >/tmp/hostname-log
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${h1}=  Run And Return Rc And Output  sha256sum /tmp/hostname |awk '{print $1}'
     Should Be Equal As Integers  ${rc}  0
@@ -168,11 +168,11 @@ Docker binary logs
     Should Be Equal As Integers  ${rc}  0
 
 Docker text logs
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run ubuntu /bin/ls >/tmp/ls
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} run ubuntu /bin/ls >/tmp/ls
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} ps -a |grep /bin/ls |awk '{print $1}'
+    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} ps -a |grep /bin/ls |awk '{print $1}'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs ${id} >/tmp/ls-log
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs ${id} >/tmp/ls-log
     Should Be Equal As Integers  ${rc}  0
     ${rc}  ${h1}=  Run And Return Rc And Output  sha256sum /tmp/ls |awk '{print $1}'
     Should Be Equal As Integers  ${rc}  0
@@ -186,29 +186,29 @@ Docker logs with timestamps and since certain time
     ${status}=  Get State Of Github Issue  2539
     Run Keyword If  '${status}' == 'closed'  Fail  Test 1-8-Docker-Logs.robot needs to be updated now that Issue #2539 has been resolved
     Log  Issue \#2539 is blocking implementation  WARN
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${containerID}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;'
+    ${rc}  ${containerID}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} create busybox /bin/sh -c 'a=0; while [ $a -lt 5 ]; do echo "line $a"; a=`expr $a + 1`; sleep 1; done;'
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} start ${containerID}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} start ${containerID}
     Should Be Equal As Integers  ${rc}  0
     Run  Sleep 6, wait for container to finish
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --since=1s ${containerID}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --since=1s ${containerID}
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  container ${containerID} does not support '--since'
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${containerID}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --timestamps ${containerID}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  container ${containerID} does not support '--timestamps'
 
 Docker logs with no flags
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d busybox sh -c "seq 1 128 | xargs -n1 echo"
+    ${rc}  ${id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} run -d busybox sh -c "seq 1 128 | xargs -n1 echo"
     Should Be Equal As Integers  ${rc}  0
     Wait Until Keyword Succeeds  20x  200 milliseconds  Grep Logs And Count Lines  ${id}  42  128
 
 Docker logs non-existent container
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs fakeContainer
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs fakeContainer
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  Error: No such container: fakeContainer
 

--- a/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
+++ b/tests/test-cases/Group1-Docker-Commands/1-08-Docker-Logs.robot
@@ -69,12 +69,12 @@ Docker logs backward compatibility
     Should Contain  ${output}  vSphere Integrated Containers does not yet support '--timestamps'
     Upgrade
     Check Upgraded Version
-    ${rc}  ${id2}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} run -d busybox sh -c "echo Whats the deeeal with Ovaltine?"
+    ${rc}  ${id2}=  Run And Return Rc And Output  docker %{VCH-PARAMS} run -d busybox sh -c "echo Whats the deeeal with Ovaltine?"
     Should Be Equal As Integers  ${rc}  0
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --timestamps ${id2}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${id2}
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Whats the deeeal with Ovaltine?
-    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} logs --timestamps ${id1}
+    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} logs --timestamps ${id1}
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  container ${id1} does not support '--timestamps'
 

--- a/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
+++ b/tests/test-cases/Group11-Upgrade/11-01-Upgrade.robot
@@ -109,7 +109,7 @@ Run Docker Checks
     Should Not Contain  ${output}  Error
 
 Create Docker Containers
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} network create bar
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} network create bar
     Should Be Equal As Integers  ${rc}  0
     Comment  Launch container on bridge network
     ${id1}  ${ip1}=  Launch Container  vch-restart-test1  bridge

--- a/tests/test-cases/Group12-VCH-BC/12-01-Delete.robot
+++ b/tests/test-cases/Group12-VCH-BC/12-01-Delete.robot
@@ -78,12 +78,12 @@ Get 0.6.0 VIC Docker Params
 *** Test Cases ***
 Delete VCH with new vic-machine
     Log To Console  \nRunning docker pull busybox...
-    ${rc}  ${output}=  Run And Return Rc And Output  docker %{VCH-PARAMS} pull busybox
+    ${rc}  ${output}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} pull busybox
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${output}  Error
     ${name}=  Generate Random String  15
-    ${rc}  ${container-id}=  Run And Return Rc And Output  docker %{VCH-PARAMS} create --name ${name} busybox /bin/top
+    ${rc}  ${container-id}=  Run And Return Rc And Output  docker1.11 %{VCH-PARAMS} create --name ${name} busybox /bin/top
     Should Be Equal As Integers  ${rc}  0
     Should Not Contain  ${container-id}  Error
     Set Suite Variable  ${containerName}  ${name}


### PR DESCRIPTION
Some integration tests deploy old vic versions, which need an older docker client.

This change uses older docker clis for these tests.

Required by #4368
Fixes #4564 #4559 #4560